### PR TITLE
Updated the ticker to include .nc files with the old naming convention

### DIFF
--- a/cproofutils/website.py
+++ b/cproofutils/website.py
@@ -86,7 +86,9 @@ def ticker(dir):
                 _log.info(d)
                 nc = sorted(glob.glob(d+'/*/L0-timeseries/*.nc'), key=os.path.getmtime)
                 if len(nc) < 1:
-                    continue
+                    nc = sorted(glob.glob(d+'/*/L1-timeseries/*.nc'), key=os.path.getmtime)
+                    if len(nc) < 1:
+                        continue
                 with xr.open_dataset(nc[-1]) as ds:  #open most recent of sorted netcdf files (last, [-1])
                     sump += ds.variables['distance_over_ground'].data[-1]                   # Add last element of dataset to final sum                    
                     list_ = np.where(ds.variables['distance_over_ground'].data==0)          # Locate where in distance over ground there is a 0,                    


### PR DESCRIPTION
Get the ticker to check distance gliders have travelled in L1-timeseries as well as L0-timeseries .nc files.