### PR TITLE
Make the correct number of grid plot subplots when missing variables

### DIFF
--- a/cproofutils/plotting.py
+++ b/cproofutils/plotting.py
@@ -317,7 +317,7 @@ def grid_plots(fname, plottingyaml):
         tmean = ds.temperature.mean(axis=1)
         indmax = np.where(~np.isnan(tmean))[0][-1]
         depmax = ds.depth[indmax]
-        fig, axs = plt.subplots(int(N / 2), 2, figsize=(7.5, 7),
+        fig, axs = plt.subplots(int(math.ceil(N / 2)), 2, figsize=(7.5, 7),
                                 sharex=True, sharey=True, constrained_layout=True)
         axs = axs.flat
         for n, k in enumerate(keys):


### PR DESCRIPTION
This change ensures that if there is an odd number of variables present, the plot still creates a sufficient number of subplots for all the variables. Changed in response to the grid plot failing when oxygen data not available from Saanich test missions. 